### PR TITLE
Update Wiz CLI to v1.x

### DIFF
--- a/.github/actions/setup-wiz/action.yml
+++ b/.github/actions/setup-wiz/action.yml
@@ -14,15 +14,15 @@ runs:
     - name: Download Wiz CLI
       if: ${{ env.DISABLE_WIZ != 'true' }}
       run: |
-        curl -Lo wizcli https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64
+        curl -Lo wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64
 
         # Import the public key
         curl -Lo public_key.asc https://downloads.wiz.io/wizcli/public_key.asc
         gpg --import public_key.asc
 
         # Download files to perform signature verification
-        curl -Lo /tmp/wizcli-sha256 https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64-sha256
-        curl -Lo /tmp/wizcli-sha256.sig https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64-sha256.sig
+        curl -Lo /tmp/wizcli-sha256 https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64-sha256
+        curl -Lo /tmp/wizcli-sha256.sig https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64-sha256.sig
 
         # Verify signature
         gpg --verify /tmp/wizcli-sha256.sig /tmp/wizcli-sha256


### PR DESCRIPTION
Wiz-CLI 0.X will reach End of Support on March 31, 2026.

https://docs.wiz.io/docs/introducing-wiz-cli-v1